### PR TITLE
add note on getting tcmalloc on Ubuntu 16.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ On OSX, you'll need to install a few packages from `brew`:
 brew install homebrew/boneyard/judy msgpack google-perftools clang-omp
 ```
 
+On Ubuntu 16.04 `trck` cannot link againt `libtcmalloc-minimal4` in the repository. In this case, use `libgoogle-perftools-dev`.
+
 You'll also need to install [TrailDB](http://traildb.io/docs/getting_started/). As of time of writing, it is recommended to install TrailDB from source as the `brew` version has a multithreading bug.
 
 ### Building


### PR DESCRIPTION
The tcmalloc-minimal4 package results in link errors but using libgoogle-perftools-dev resolves the issue on Xenial. This change updates the readme with a note to this effect.

This updates the readme based on #5 