### PR TITLE
Gettrail print use library for inner obj

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ bin/gettrail: src/gettrail.c
 		$(CC) -std=c99  -O3 -g -Wall -Wno-unused-variable -Wno-unused-label -DDEBUG=$(DEBUG) $(INCLUDEPATH) $^ -ltraildb -lJudy -lcurl -ltraildb -ljson-c -o $@
 
 bin/gettrail_print: src/gettrail_print.c
-		$(CC) -std=c99  -O3 -g -Wall -Wno-unused-variable -Wno-unused-label -DDEBUG=$(DEBUG) $(INCLUDEPATH) $^ -ltraildb -lJudy -lcurl -ltraildb -o $@
+		$(CC) -std=c99  -O3 -g -Wall -Wno-unused-variable -Wno-unused-label -DDEBUG=$(DEBUG) $(INCLUDEPATH) $^ -ltraildb -lJudy -lcurl -ltraildb -ljson-c -o $@
 
 bin/gettrail_tdb: src/gettrail_tdb.c src/traildb_filter.c
 	$(CC) -std=c99  -O3 -g -Wall -DDEBUG=$(DEBUG) $(INCLUDEPATH) $^ -ltraildb -lJudy -lcurl -ltraildb -ljson-c -o $@

--- a/enter_docker_env.sh
+++ b/enter_docker_env.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-DOCKER_ENV="771945457201.dkr.ecr.us-west-2.amazonaws.com/trck:latest"
-
-docker run --rm -v $PWD:/opt/trck -v /mnt/data:/mnt/data -w /opt/trck -it $DOCKER_ENV /bin/bash

--- a/src/gettrail.c
+++ b/src/gettrail.c
@@ -53,7 +53,7 @@ struct json_object *get_trails(char **traildb_paths, int num_paths, Pvoid_t cook
                         const char *field_value = tdb_get_item_value(db, event->items[k-1], &len);
                         if(field_value != NULL)
                             json_object_object_add(jitem, field_name, json_object_new_string_len(field_value, len));
-                        
+
                     }
                     json_object_array_add(jarr, jitem);
                 }
@@ -111,5 +111,5 @@ int main(int argc, char **argv) {
     const char *json_string = json_object_to_json_string(res);
     printf("%s", json_string);
     json_object_put(res);
-    
+
 }

--- a/src/gettrail_print.c
+++ b/src/gettrail_print.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <traildb.h>
 #include <Judy.h>
+#include <json-c/json.h>
 #include <stdbool.h>
 #include <string.h>
 
@@ -50,40 +51,26 @@ void print_trails(char **traildb_paths, int num_paths, Pvoid_t cookies) {
                 printf("[");
                 int ei = 0;
                 while ((event = tdb_cursor_next(cursor))) {
-                    if (ei == 0) {
-                        printf("{");
-                    } else {
-                        printf(",{");
+                    struct json_object *jitem = json_object_new_object();
+
+                    if (ei != 0) {
+                        printf(",");
                     }
 
                     timestamp_t ts = (timestamp_t)event->timestamp;
-                    printf("\"timestamp\": %" PRIu64 ",", ts);
+                    json_object_object_add(jitem, "timestamp", json_object_new_int64(ts));
 
                     for (int k = 1; k < num_fields; k++) {
                         const char *field_name = tdb_get_field_name(db, k);
                         uint64_t len;
                         const char *field_value = tdb_get_item_value(db, event->items[k-1], &len);
-                        if(field_value != NULL) {
-                            printf("\"%s\": \"", field_name);
-
-                            // Print each character individually, skipping over quotes.
-                            for (uint64_t fi = 0; fi < len; fi++) {
-                                if (field_value[fi] != '"') {
-                                    putchar(field_value[fi]);
-                                }
-                            }
-
-                            // Add the closing quote for the field_value.
-                            if (k == num_fields - 1) {
-                                printf("\"");
-                            } else {
-                                printf("\",");
-                            }
-                        }
-
+                        if (field_value != NULL)
+                            json_object_object_add(jitem, field_name, json_object_new_string_len(field_value, len));
                     }
-                    printf("}");
+
+                    printf("%s", json_object_to_json_string(jitem));
                     ei++;
+                    json_object_put(jitem);
                 }
                 printf("]");
             }


### PR DESCRIPTION
@rcjmurillo @badi @aholyoke 

By using the `json-c` library for a given event, we can properly escape strings. This still avoids using the library for everything, because we could be creating really long arrays.

I tested this by running it over a traildb and comparison its JSON output to that of `gettrail`.